### PR TITLE
OpenTripPlanner modes adapter and ferry calculation

### DIFF
--- a/estimator/README.md
+++ b/estimator/README.md
@@ -57,17 +57,19 @@ This library intends to provide:
 - a statistical estimate of greenhouse gase emissions given information about a trip (origin/destination, mode, and/or distance)
 - a simple interpretation of the statistical emissions estimate, in terms such as "high" or "low"
 
-## Research
+## Carbon estimates
 
-The carbon estimates produced by this model may be based on the following resources. A full description of the model, including data sources, will be provided as the library takes shape.
+We try to provide a "best effort" estimate of CO2 emissions for transportation modes defined by the OpenTripPlanner project.
 
-- European Environment Agency [CO2 emissions from passenger transport](https://www.eea.europa.eu/media/infographics/co2-emissions-from-passenger-transport/view)
+Our baseline estimates come from an infographic published by the European Environment Agency: [CO2 emissions from passenger transport](https://www.eea.europa.eu/media/infographics/co2-emissions-from-passenger-transport/view).
 
-For modes not covered in the EEA infographic, we have used approximations and averages to provide estimates for all OpenTripPlanner modes.
+For modes not covered in the EEA infographic, we have used data from other sources (described below). In some cases, we have simply averaged values for several modes to provide estimates for more ambiguous modes, like **CAR** and **TRANSIT**. 
 
-For Ferry mode calculation we use the average of 6.8 MJ per passenger kilometer with an average occupancy of 184 (Schiller & Kenworthy, 2017, pp. 142–143). We then used the procedure described in the following section in order to map megajoules to grams CO2 per passenger kilometer.
+Some mode energy estimates are based on **megajoules for the petroleum consumed**. For those modes, we used a **petroleum average of 12g CO2 eq. per megajoule** (The International Council on Clean Transportation, 2010).
 
-With an average of 12g CO2 eq. per megajoule (The International Council on Clean Transportation, 2010), we estimate that each ferry passenger kilometer approximates to 81.6 g CO2.
+For **FERRY** mode calculation we use the average of 6.8 MJ per passenger kilometer with an average occupancy of 91 (Schiller & Kenworthy, 2017, p. 143-144). We then estimate that each ferry passenger kilometer approximates to 81.6 g CO2, based on the above petroleum megajoule to grams CO2 conversion factor (6.8 * 12).
+
+For **SUBWAY** (metro) mode calculation we use the average of 0.52 MJ per passenger kilometer with an average occupancy of 31 (Schiller & Kenworthy, 2017, pp. 143-144). We then estimate that each metro passenger kilometer approximates to 6.24 grams of CO2, based on the above petroleum megajoule to grams CO2 conversion factor (0.52 * 12).
 
 ### Bibliography
 - The International Council on Clean Transportation. (2010). Carbon Intensity of Crude Oil in Europe. Retrieved from https://theicct.org/sites/default/files/ICCT_crudeoil_Eur_Dec2010_sum.pdf

--- a/estimator/README.md
+++ b/estimator/README.md
@@ -63,6 +63,18 @@ The carbon estimates produced by this model may be based on the following resour
 
 - European Environment Agency [CO2 emissions from passenger transport](https://www.eea.europa.eu/media/infographics/co2-emissions-from-passenger-transport/view)
 
+For modes not covered in the EEA infographic, we have used approximations and averages to provide estimates for all OpenTripPlanner modes.
+
+For Ferry mode calculation we use the average of 6.8 MJ per passenger kilometer with an average occupancy of 184 (Schiller & Kenworthy, 2017, pp. 142–143). We then used the procedure described in the following section in order to map megajoules to grams CO2 per passenger kilometer.
+
+With an average of 12g CO2 eq. per megajoule (The International Council on Clean Transportation, 2010), we estimate that each ferry passenger kilometer approximates to 81.6 g CO2.
+
+### Bibliography
+- The International Council on Clean Transportation. (2010). Carbon Intensity of Crude Oil in Europe. Retrieved from https://theicct.org/sites/default/files/ICCT_crudeoil_Eur_Dec2010_sum.pdf
+- Schiller, P. L., & Kenworthy, J. R. (2017). An Introduction to Sustainable Transportation. Abingdon, United Kingdom: Routledge.
+
+
+### Further reading
 Further improvements to the model may come from other sources, such as the following.
 
 - IPCC AR5 [Chapter 8 - Transport](https://www.ipcc.ch/site/assets/uploads/2018/02/ipcc_wg3_ar5_chapter8.pdf)

--- a/estimator/transport_co2/model.py
+++ b/estimator/transport_co2/model.py
@@ -9,13 +9,14 @@ from typing import Optional
 
 def calculate_mean_of_transport_modes(modes: list) -> tuple:
     """
-        For use in ambiguous modes where  CO2 grams per km and occupancy values are not available.
+    For use in ambiguous modes where  CO2 grams per km and occupancy values are not available.
 
-        Given a list of multiple transport modes, calculate the average (mean)
-        CO2 grams per kilometer and occupancy
+    Given a list of multiple transport modes, calculate the average (mean)
+    CO2 grams per kilometer and occupancy
 
-        Return a tuple with the calculated averages.
-        """
+    Return a tuple with the calculated averages.
+    """
+
     co2_per_km_values, occupancy_values = zip(*modes)
 
     average_co2_per_km = mean(co2_per_km_values)

--- a/estimator/transport_co2/model.py
+++ b/estimator/transport_co2/model.py
@@ -55,7 +55,7 @@ class Mode(Enum):
         self.avg_co2_per_vehicle_km = avg_co2_per_vehicle_km
         self.avg_occupancy = avg_occupancy
 
-    def __calculate_mean_of_transport_modes(modes: list):
+    def __calculate_mean_of_transport_modes(modes: list) -> tuple:
         """
         For use in ambiguous modes where  CO2 grams per km and occupancy values are not available.
 

--- a/estimator/transport_co2/model.py
+++ b/estimator/transport_co2/model.py
@@ -42,15 +42,34 @@ class Fuel(Enum):
 
 class Mode(Enum):
     """
-    Data structure containing grams of CO2/vehicle KM for several modes of transport
-    along with average occupancy for each mode.
+    Tuples for several modes of transport, each containing:
+    - average grams of CO2 per vehicle kilometer
+    - average vehicle occupancy.
 
-    See the library README for sources and a description of how we arrive at these CO2 values.
+    The modes of transport come from the OpenTripPlanner project.
+
+    See the library README for data sources and a description of how we arrive at these CO2 values.
     """
 
     def __init__(self, avg_co2_per_vehicle_km: float, avg_occupancy: float):
         self.avg_co2_per_vehicle_km = avg_co2_per_vehicle_km
         self.avg_occupancy = avg_occupancy
+
+    def __calculate_mean_of_transport_modes(modes: list):
+        """
+        For use in ambiguous modes where  CO2 grams per km and occupancy values are not available.
+
+        Given a list of multiple transport modes, calculate the average (mean)
+        CO2 grams per kilometer and occupancy
+
+        Return a tuple with the calculated averages.
+        """
+        co2_per_km_values, occupancy_values = zip(*modes)
+
+        average_co2_per_km = mean(co2_per_km_values)
+        average_vehicle_occupancy = mean(occupancy_values)
+
+        return (average_co2_per_km, average_vehicle_occupancy)
 
     LIGHT_RAIL = (2184, 156)
     SMALL_CAR = (168, 1.5)
@@ -61,15 +80,15 @@ class Mode(Enum):
     # Additional OTP modes
     WALK = (0, 1)
     BICYCLE = (0, 1)
-    CAR = (mean([SMALL_CAR[0], LARGE_CAR[0]]), 1.5)
+    CAR = __calculate_mean_of_transport_modes([SMALL_CAR, LARGE_CAR])
     TRAM = LIGHT_RAIL
-    SUBWAY = LIGHT_RAIL
+    SUBWAY = (193.44, 31)
     RAIL = LIGHT_RAIL
-    FERRY = (15014.4, 184)
+    FERRY = (7425.6, 91)
     CABLE_CAR = LIGHT_RAIL
     GONDOLA = LIGHT_RAIL
     FUNICULAR = LIGHT_RAIL
-    TRANSIT = BUS
+    TRANSIT = __calculate_mean_of_transport_modes([BUS, LIGHT_RAIL, SUBWAY])
     LEG_SWITCH = (0, 1)
     AIRPLANE = (25080, 88)
 

--- a/estimator/transport_co2/model.py
+++ b/estimator/transport_co2/model.py
@@ -7,6 +7,22 @@ from statistics import mean
 from typing import Optional
 
 
+def calculate_mean_of_transport_modes(modes: list) -> tuple:
+        """
+        For use in ambiguous modes where  CO2 grams per km and occupancy values are not available.
+
+        Given a list of multiple transport modes, calculate the average (mean)
+        CO2 grams per kilometer and occupancy
+
+        Return a tuple with the calculated averages.
+        """
+        co2_per_km_values, occupancy_values = zip(*modes)
+
+        average_co2_per_km = mean(co2_per_km_values)
+        average_vehicle_occupancy = mean(occupancy_values)
+
+        return (average_co2_per_km, average_vehicle_occupancy)
+
 class Fuel(Enum):
     """
     Data structure for estimating grams of CO2 per litre of various fuel types.
@@ -55,22 +71,6 @@ class Mode(Enum):
         self.avg_co2_per_vehicle_km = avg_co2_per_vehicle_km
         self.avg_occupancy = avg_occupancy
 
-    def __calculate_mean_of_transport_modes(modes: list) -> tuple:
-        """
-        For use in ambiguous modes where  CO2 grams per km and occupancy values are not available.
-
-        Given a list of multiple transport modes, calculate the average (mean)
-        CO2 grams per kilometer and occupancy
-
-        Return a tuple with the calculated averages.
-        """
-        co2_per_km_values, occupancy_values = zip(*modes)
-
-        average_co2_per_km = mean(co2_per_km_values)
-        average_vehicle_occupancy = mean(occupancy_values)
-
-        return (average_co2_per_km, average_vehicle_occupancy)
-
     LIGHT_RAIL = (2184, 156)
     SMALL_CAR = (168, 1.5)
     LARGE_CAR = (220, 1.5)
@@ -80,7 +80,7 @@ class Mode(Enum):
     # Additional OTP modes
     WALK = (0, 1)
     BICYCLE = (0, 1)
-    CAR = __calculate_mean_of_transport_modes([SMALL_CAR, LARGE_CAR])
+    CAR = calculate_mean_of_transport_modes([SMALL_CAR, LARGE_CAR])
     TRAM = LIGHT_RAIL
     SUBWAY = (193.44, 31)
     RAIL = LIGHT_RAIL
@@ -88,7 +88,7 @@ class Mode(Enum):
     CABLE_CAR = LIGHT_RAIL
     GONDOLA = LIGHT_RAIL
     FUNICULAR = LIGHT_RAIL
-    TRANSIT = __calculate_mean_of_transport_modes([BUS, LIGHT_RAIL, SUBWAY])
+    TRANSIT = calculate_mean_of_transport_modes([BUS, LIGHT_RAIL, SUBWAY])
     LEG_SWITCH = (0, 1)
     AIRPLANE = (25080, 88)
 

--- a/estimator/transport_co2/model.py
+++ b/estimator/transport_co2/model.py
@@ -3,6 +3,7 @@
 """Modes along with their data and estimator."""
 
 from enum import Enum
+from statistics import mean
 from typing import Optional
 
 
@@ -44,10 +45,7 @@ class Mode(Enum):
     Data structure containing grams of CO2/vehicle KM for several modes of transport
     along with average occupancy for each mode.
 
-    Source data:
-    CO2 emissions from passenger transport
-    from European Environment Agency
-    https://www.eea.europa.eu/media/infographics/co2-emissions-from-passenger-transport/view
+    See the library README for sources and a description of how we arrive at these CO2 values.
     """
 
     def __init__(self, avg_co2_per_vehicle_km: float, avg_occupancy: float):
@@ -59,6 +57,21 @@ class Mode(Enum):
     LARGE_CAR = (220, 1.5)
     SCOOTER = (86.4, 1.2)
     BUS = (863, 12.7)
+
+    # Additional OTP modes
+    WALK = (0, 1)
+    BICYCLE = (0, 1)
+    CAR = (mean([SMALL_CAR[0], LARGE_CAR[0]]), 1.5)
+    TRAM = LIGHT_RAIL
+    SUBWAY = LIGHT_RAIL
+    RAIL = LIGHT_RAIL
+    FERRY = (15014.4, 184)
+    CABLE_CAR = LIGHT_RAIL
+    GONDOLA = LIGHT_RAIL
+    FUNICULAR = LIGHT_RAIL
+    TRANSIT = BUS
+    LEG_SWITCH = (0, 1)
+    AIRPLANE = (25080, 88)
 
     def estimate_co2(
         self,

--- a/estimator/transport_co2/model.py
+++ b/estimator/transport_co2/model.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 
 def calculate_mean_of_transport_modes(modes: list) -> tuple:
-        """
+    """
         For use in ambiguous modes where  CO2 grams per km and occupancy values are not available.
 
         Given a list of multiple transport modes, calculate the average (mean)
@@ -16,12 +16,13 @@ def calculate_mean_of_transport_modes(modes: list) -> tuple:
 
         Return a tuple with the calculated averages.
         """
-        co2_per_km_values, occupancy_values = zip(*modes)
+    co2_per_km_values, occupancy_values = zip(*modes)
 
-        average_co2_per_km = mean(co2_per_km_values)
-        average_vehicle_occupancy = mean(occupancy_values)
+    average_co2_per_km = mean(co2_per_km_values)
+    average_vehicle_occupancy = mean(occupancy_values)
 
-        return (average_co2_per_km, average_vehicle_occupancy)
+    return (average_co2_per_km, average_vehicle_occupancy)
+
 
 class Fuel(Enum):
     """
@@ -76,8 +77,6 @@ class Mode(Enum):
     LARGE_CAR = (220, 1.5)
     SCOOTER = (86.4, 1.2)
     BUS = (863, 12.7)
-
-    # Additional OTP modes
     WALK = (0, 1)
     BICYCLE = (0, 1)
     CAR = calculate_mean_of_transport_modes([SMALL_CAR, LARGE_CAR])

--- a/estimator/transport_co2/tests/test_transport_co2_estimator.py
+++ b/estimator/transport_co2/tests/test_transport_co2_estimator.py
@@ -1,116 +1,164 @@
-from pytest import approx
+from pytest import approx, fail
 from transport_co2.estimator import estimate_co2, estimate_fuel_co2_g
 
-
-# Only distance
-def test_estimate_co2_bus():
-    co2_estimate = estimate_co2(mode="bus", distance_in_km=10)
-
-    assert co2_estimate == approx(679.5275590551181)
+from transport_co2.model import Fuel, Mode
 
 
-def test_estimate_co2_light_rail():
-    co2_estimate = estimate_co2(mode="light_rail", distance_in_km=10)
+# Get list of supported transport modes and fuel types
+# by excluding Python API methods
+transport_modes = [
+    transport_mode
+    for transport_mode in Mode.__members__
+    if not transport_mode.startswith("_")
+]
 
-    assert co2_estimate == approx(140)
-
-
-def test_estimate_co2_small_car():
-    co2_estimate = estimate_co2(mode="small_car", distance_in_km=10)
-
-    assert co2_estimate == approx(1120)
-
-
-def test_estimate_co2_large_car():
-    co2_estimate = estimate_co2(mode="large_car", distance_in_km=10)
-
-    assert co2_estimate == approx(1466.6666666666667)
+fuel_types = [
+    fuel_type for fuel_type in Fuel.__members__ if not fuel_type.startswith("_")
+]
 
 
-def test_estimate_co2_scooter():
-    co2_estimate = estimate_co2(mode="scooter", distance_in_km=10)
+def test_estimate_co2():
+    """
+    Test CO2 estimates for default transport mode values
+    """
 
-    assert co2_estimate == approx(720)
+    for transport_mode in transport_modes:
+        co2_estimate = estimate_co2(mode=transport_mode.lower(), distance_in_km=10)
+
+        if transport_mode == "LIGHT_RAIL":
+            assert co2_estimate == approx(140)
+        elif transport_mode == "SMALL_CAR":
+            assert co2_estimate == approx(1_120)
+        elif transport_mode == "LARGE_CAR":
+            assert co2_estimate == approx(1_466.6666666666667)
+        elif transport_mode == "SCOOTER":
+            assert co2_estimate == approx(720)
+        elif transport_mode == "BUS":
+            assert co2_estimate == approx(679.5275590551181)
+        elif transport_mode == "WALK":
+            assert co2_estimate == approx(0)
+        elif transport_mode == "BICYCLE":
+            assert co2_estimate == approx(0)
+        elif transport_mode == "CAR":
+            assert co2_estimate == approx(1_293.3333333333333)
+        elif transport_mode == "TRAM":
+            assert co2_estimate == approx(140.0)
+        elif transport_mode == "SUBWAY":
+            assert co2_estimate == approx(62.400000000000006)
+        elif transport_mode == "RAIL":
+            assert co2_estimate == approx(140.0)
+        elif transport_mode == "FERRY":
+            assert co2_estimate == approx(816.0)
+        elif transport_mode == "CABLE_CAR":
+            assert co2_estimate == approx(140.0)
+        elif transport_mode == "GONDOLA":
+            assert co2_estimate == approx(140.0)
+        elif transport_mode == "FUNICULAR":
+            assert co2_estimate == approx(140.0)
+        elif transport_mode == "TRANSIT":
+            assert co2_estimate == approx(162.26539809714575)
+        elif transport_mode == "LEG_SWITCH":
+            assert co2_estimate == approx(0)
+        elif transport_mode == "AIRPLANE":
+            assert co2_estimate == approx(2_850.0)
+        else:
+            # Make sure we don't miss any test cases
+            # or have unexpected members
+            fail(f"No test case for { transport_mode }")
 
 
-# Distance and occupancy
-def test_estimate_co2_bus_with_occupancy():
-    co2_estimate = estimate_co2(mode="bus", distance_in_km=10, occupancy=10)
+def test_estimate_co2_with_occupancy():
+    """
+    Make sure we get correct result
+    when user provides occupancy count
+    """
 
-    assert co2_estimate == approx(863)
+    for transport_mode in transport_modes:
+        co2_estimate = estimate_co2(
+            mode=transport_mode.lower(), distance_in_km=10, occupancy=1
+        )
 
-
-def test_estimate_co2_light_rail_with_occupancy():
-    co2_estimate = estimate_co2(
-        mode="light_rail", distance_in_km=10, occupancy=100)
-
-    assert co2_estimate == approx(218.4)
-
-
-def test_estimate_co2_small_car_with_occupancy():
-    co2_estimate = estimate_co2(
-        mode="small_car", distance_in_km=10, occupancy=2)
-
-    assert co2_estimate == approx(840.0)
-
-
-def test_estimate_co2_large_car_with_occupancy():
-    co2_estimate = estimate_co2(
-        mode="large_car", distance_in_km=10, occupancy=3)
-
-    assert co2_estimate == approx(733.3333333333334)
-
-
-def test_estimate_co2_scooter_with_occupancy():
-    co2_estimate = estimate_co2(mode="scooter", distance_in_km=10, occupancy=2)
-
-    assert co2_estimate == approx(432.0)
+        if transport_mode == "LIGHT_RAIL":
+            assert co2_estimate == approx(21_840.0)
+        elif transport_mode == "SMALL_CAR":
+            assert co2_estimate == approx(1_680.0)
+        elif transport_mode == "LARGE_CAR":
+            assert co2_estimate == approx(2_200.0)
+        elif transport_mode == "SCOOTER":
+            assert co2_estimate == approx(864.0)
+        elif transport_mode == "BUS":
+            assert co2_estimate == approx(8_630.0)
+        elif transport_mode == "WALK":
+            assert co2_estimate == approx(0)
+        elif transport_mode == "BICYCLE":
+            assert co2_estimate == approx(0)
+        elif transport_mode == "CAR":
+            assert co2_estimate == approx(1_940.0)
+        elif transport_mode == "TRAM":
+            assert co2_estimate == approx(21_840.0)
+        elif transport_mode == "SUBWAY":
+            assert co2_estimate == approx(1_934.4)
+        elif transport_mode == "RAIL":
+            assert co2_estimate == approx(21_840.0)
+        elif transport_mode == "FERRY":
+            assert co2_estimate == approx(74_256.0)
+        elif transport_mode == "CABLE_CAR":
+            assert co2_estimate == approx(21_840.0)
+        elif transport_mode == "GONDOLA":
+            assert co2_estimate == approx(21_840.0)
+        elif transport_mode == "FUNICULAR":
+            assert co2_estimate == approx(21_840.0)
+        elif transport_mode == "TRANSIT":
+            assert co2_estimate == approx(10801.466666666667)
+        elif transport_mode == "LEG_SWITCH":
+            assert co2_estimate == approx(0)
+        elif transport_mode == "AIRPLANE":
+            assert co2_estimate == approx(250800.0)
+        else:
+            # Make sure we don't miss any test cases
+            # or have unexpected members
+            fail(f"No test case for { transport_mode }")
 
 
 # Fuel
+def test_estimate_fuel_co2_g():
+    """
+    Make sure we get correct result for default CO2/litre values
+    """
 
-# Fuel type and litres
-def test_estimate_fuel_co2_g_petrol():
-    co2_estimate = estimate_fuel_co2_g(fuel="petrol", litres=1)
+    for fuel_type in fuel_types:
+        co2_estimate = estimate_fuel_co2_g(fuel=fuel_type, litres=1)
 
-    assert co2_estimate == approx(2_290)
-
-
-def test_estimate_fuel_co2_g_ethanol_10():
-    co2_estimate = estimate_fuel_co2_g(fuel="ethanol_10", litres=1)
-
-    assert co2_estimate == approx(2_210)
-
-
-def test_estimate_fuel_co2_g_ethanol_85():
-    co2_estimate = estimate_fuel_co2_g(fuel="ethanol_85", litres=1)
-
-    assert co2_estimate == approx(1_610)
-
-
-def test_estimate_fuel_co2_g_diesel():
-    co2_estimate = estimate_fuel_co2_g(fuel="diesel", litres=1)
-
-    assert co2_estimate == approx(2_660)
-
-
-def test_estimate_fuel_co2_g_biodiesel_5():
-    co2_estimate = estimate_fuel_co2_g(fuel="biodiesel_5", litres=1)
-
-    assert co2_estimate == approx(2_650)
-
-
-def test_estimate_fuel_co2_g_biodiesel_20():
-    co2_estimate = estimate_fuel_co2_g(fuel="biodiesel_20", litres=1)
-
-    assert co2_estimate == approx(2_620)
-
-# custom co2_g_per_litre
+        if fuel_type == "PETROL":
+            assert co2_estimate == approx(2_290)
+        elif fuel_type == "ETHANOL_10":
+            assert co2_estimate == approx(2_210)
+        elif fuel_type == "ETHANOL_85":
+            assert co2_estimate == approx(1_610)
+        elif fuel_type == "DIESEL":
+            assert co2_estimate == approx(2_660)
+        elif fuel_type == "BIODIESEL_5":
+            assert co2_estimate == approx(2_650)
+        elif fuel_type == "BIODIESEL_20":
+            assert co2_estimate == approx(2_620)
+        else:
+            # Make sure we don't miss any test cases
+            # or have unexpected members
+            fail(f"No test case for { fuel_type }")
 
 
 def test_estimate_fuel_custom_co2_g_per_litre():
-    co2_g_per_litre = 1_000
-    co2_estimate = estimate_fuel_co2_g(
-        fuel="biodiesel_20", litres=1, co2_g_per_litre=co2_g_per_litre)
+    """
+    Make sure we get correct result
+    when user overrides CO2 g per litre
+    """
 
-    assert co2_estimate == approx(1_000)
+    co2_g_per_litre = 1_000
+
+    # Test using one litre,
+    # so value will match variable
+    co2_estimate = estimate_fuel_co2_g(
+        fuel="biodiesel_20", litres=1, co2_g_per_litre=co2_g_per_litre
+    )
+
+    assert co2_estimate == approx(co2_g_per_litre)

--- a/estimator/transport_co2/tests/test_transport_co2_model.py
+++ b/estimator/transport_co2/tests/test_transport_co2_model.py
@@ -1,116 +1,203 @@
-from pytest import approx
+from pytest import approx, fail
 from transport_co2.model import Fuel, Mode
 
+
+# Get list of supported transport modes and fuel types
+# by excluding Python API methods
+transport_modes = [
+    transport_mode
+    for transport_mode in Mode.__members__
+    if not transport_mode.startswith("_")
+]
+
+fuel_types = [
+    fuel_type for fuel_type in Fuel.__members__ if not fuel_type.startswith("_")
+]
+
+
 # Mode
+def test_allowed_transport_modes():
+    """
+    Mode enum should only have allowed transport modes
+    """
 
-# Only distance
+    allowed_transport_modes = [
+        "LIGHT_RAIL",
+        "SMALL_CAR",
+        "LARGE_CAR",
+        "SCOOTER",
+        "BUS",
+        "WALK",
+        "BICYCLE",
+        "CAR",
+        "TRAM",
+        "SUBWAY",
+        "RAIL",
+        "FERRY",
+        "CABLE_CAR",
+        "GONDOLA",
+        "FUNICULAR",
+        "TRANSIT",
+        "LEG_SWITCH",
+        "AIRPLANE",
+    ]
 
-
-def test_estimate_co2_bus():
-    co2_estimate = Mode.BUS.estimate_co2(distance_in_km=10)
-
-    assert co2_estimate == approx(679.5275590551181)
-
-
-def test_estimate_co2_light_rail():
-    co2_estimate = Mode.LIGHT_RAIL.estimate_co2(distance_in_km=10)
-
-    assert co2_estimate == approx(140)
-
-
-def test_estimate_co2_small_car():
-    co2_estimate = Mode.SMALL_CAR.estimate_co2(distance_in_km=10)
-
-    assert co2_estimate == approx(1120)
-
-
-def test_estimate_co2_large_car():
-    co2_estimate = Mode.LARGE_CAR.estimate_co2(distance_in_km=10)
-
-    assert co2_estimate == approx(1466.6666666666667)
-
-
-def test_estimate_co2_scooter():
-    co2_estimate = Mode.SCOOTER.estimate_co2(distance_in_km=10)
-
-    assert co2_estimate == approx(720)
+    assert transport_modes == allowed_transport_modes
 
 
-## Distance and occupancy
-def test_estimate_co2_bus_with_occupancy():
-    co2_estimate = Mode.BUS.estimate_co2(distance_in_km=10, occupancy=10)
+def test_mode_estimate_co2():
+    """
+    Test CO2 estimates for default transport mode values
+    """
 
-    assert co2_estimate == approx(863)
+    for transport_mode in transport_modes:
+        co2_estimate = Mode[transport_mode].estimate_co2(distance_in_km=10)
+
+        if transport_mode == "LIGHT_RAIL":
+            assert co2_estimate == approx(140)
+        elif transport_mode == "SMALL_CAR":
+            assert co2_estimate == approx(1_120)
+        elif transport_mode == "LARGE_CAR":
+            assert co2_estimate == approx(1_466.6666666666667)
+        elif transport_mode == "SCOOTER":
+            assert co2_estimate == approx(720)
+        elif transport_mode == "BUS":
+            assert co2_estimate == approx(679.5275590551181)
+        elif transport_mode == "WALK":
+            assert co2_estimate == approx(0)
+        elif transport_mode == "BICYCLE":
+            assert co2_estimate == approx(0)
+        elif transport_mode == "CAR":
+            assert co2_estimate == approx(1_293.3333333333333)
+        elif transport_mode == "TRAM":
+            assert co2_estimate == approx(140.0)
+        elif transport_mode == "SUBWAY":
+            assert co2_estimate == approx(62.400000000000006)
+        elif transport_mode == "RAIL":
+            assert co2_estimate == approx(140.0)
+        elif transport_mode == "FERRY":
+            assert co2_estimate == approx(816.0)
+        elif transport_mode == "CABLE_CAR":
+            assert co2_estimate == approx(140.0)
+        elif transport_mode == "GONDOLA":
+            assert co2_estimate == approx(140.0)
+        elif transport_mode == "FUNICULAR":
+            assert co2_estimate == approx(140.0)
+        elif transport_mode == "TRANSIT":
+            assert co2_estimate == approx(162.26539809714575)
+        elif transport_mode == "LEG_SWITCH":
+            assert co2_estimate == approx(0)
+        elif transport_mode == "AIRPLANE":
+            assert co2_estimate == approx(2_850.0)
+        else:
+            # Make sure we don't miss any test cases
+            # or have unexpected members
+            fail(f"No test case for { transport_mode }")
 
 
-def test_estimate_co2_light_rail_with_occupancy():
-    co2_estimate = Mode.LIGHT_RAIL.estimate_co2(
-        distance_in_km=10, occupancy=100)
+def test_mode_estimate_co2_with_occupancy():
+    """
+    Make sure we get correct result
+    when user provides occupancy count
+    """
 
-    assert co2_estimate == approx(218.4)
+    for transport_mode in transport_modes:
+        co2_estimate = Mode[transport_mode].estimate_co2(distance_in_km=10, occupancy=1)
 
-
-def test_estimate_co2_small_car_with_occupancy():
-    co2_estimate = Mode.SMALL_CAR.estimate_co2(distance_in_km=10, occupancy=2)
-
-    assert co2_estimate == approx(840.0)
-
-
-def test_estimate_co2_large_car_with_occupancy():
-    co2_estimate = Mode.LARGE_CAR.estimate_co2(distance_in_km=10, occupancy=3)
-
-    assert co2_estimate == approx(733.3333333333334)
-
-
-def test_estimate_co2_scooter_with_occupancy():
-    co2_estimate = Mode.SCOOTER.estimate_co2(distance_in_km=10, occupancy=2)
-
-    assert co2_estimate == approx(432.0)
+        if transport_mode == "LIGHT_RAIL":
+            assert co2_estimate == approx(21_840.0)
+        elif transport_mode == "SMALL_CAR":
+            assert co2_estimate == approx(1_680.0)
+        elif transport_mode == "LARGE_CAR":
+            assert co2_estimate == approx(2_200.0)
+        elif transport_mode == "SCOOTER":
+            assert co2_estimate == approx(864.0)
+        elif transport_mode == "BUS":
+            assert co2_estimate == approx(8_630.0)
+        elif transport_mode == "WALK":
+            assert co2_estimate == approx(0)
+        elif transport_mode == "BICYCLE":
+            assert co2_estimate == approx(0)
+        elif transport_mode == "CAR":
+            assert co2_estimate == approx(1_940.0)
+        elif transport_mode == "TRAM":
+            assert co2_estimate == approx(21_840.0)
+        elif transport_mode == "SUBWAY":
+            assert co2_estimate == approx(1_934.4)
+        elif transport_mode == "RAIL":
+            assert co2_estimate == approx(21_840.0)
+        elif transport_mode == "FERRY":
+            assert co2_estimate == approx(74_256.0)
+        elif transport_mode == "CABLE_CAR":
+            assert co2_estimate == approx(21_840.0)
+        elif transport_mode == "GONDOLA":
+            assert co2_estimate == approx(21_840.0)
+        elif transport_mode == "FUNICULAR":
+            assert co2_estimate == approx(21_840.0)
+        elif transport_mode == "TRANSIT":
+            assert co2_estimate == approx(10801.466666666667)
+        elif transport_mode == "LEG_SWITCH":
+            assert co2_estimate == approx(0)
+        elif transport_mode == "AIRPLANE":
+            assert co2_estimate == approx(250800.0)
+        else:
+            # Make sure we don't miss any test cases
+            # or have unexpected members
+            fail(f"No test case for { transport_mode }")
 
 
 # Fuel
+def test_allowed_fuel_types():
+    """
+    Mode enum should only have allowed fuel types
+    """
 
-# Only litres
-def test_fuel_co2_estimate_petrol():
-    co2_estimate_g = Fuel.PETROL.estimate_co2_g(litres=1)
+    allowed_fuel_types = [
+        "PETROL",
+        "ETHANOL_10",
+        "ETHANOL_85",
+        "DIESEL",
+        "BIODIESEL_5",
+        "BIODIESEL_20",
+    ]
 
-    assert co2_estimate_g == approx(2_290)
-
-
-def test_fuel_co2_estimate_ethanol_10():
-    co2_estimate_g = Fuel.ETHANOL_10.estimate_co2_g(litres=1)
-
-    assert co2_estimate_g == approx(2_210)
-
-
-def test_fuel_co2_estimate_ethanol_85():
-    co2_estimate_g = Fuel.ETHANOL_85.estimate_co2_g(litres=1)
-
-    assert co2_estimate_g == approx(1_610)
+    assert fuel_types == allowed_fuel_types
 
 
-def test_fuel_co2_estimate_diesel():
-    co2_estimate_g = Fuel.DIESEL.estimate_co2_g(litres=1)
+def test_estimate_fuel_co2_g():
+    """
+    Make sure we get correct result for default CO2/litre values
+    """
 
-    assert co2_estimate_g == approx(2_660)
+    for fuel_type in fuel_types:
+        co2_estimate = Fuel[fuel_type].estimate_co2_g(litres=1)
 
-
-def test_fuel_co2_estimate_biodiesel_5():
-    co2_estimate_g = Fuel.BIODIESEL_5.estimate_co2_g(litres=1)
-
-    assert co2_estimate_g == approx(2_650)
-
-
-def test_fuel_co2_estimate_biodiesel_20():
-    co2_estimate_g = Fuel.BIODIESEL_20.estimate_co2_g(litres=1)
-
-    assert co2_estimate_g == approx(2_620)
+        if fuel_type == "PETROL":
+            assert co2_estimate == approx(2_290)
+        elif fuel_type == "ETHANOL_10":
+            assert co2_estimate == approx(2_210)
+        elif fuel_type == "ETHANOL_85":
+            assert co2_estimate == approx(1_610)
+        elif fuel_type == "DIESEL":
+            assert co2_estimate == approx(2_660)
+        elif fuel_type == "BIODIESEL_5":
+            assert co2_estimate == approx(2_650)
+        elif fuel_type == "BIODIESEL_20":
+            assert co2_estimate == approx(2_620)
+        else:
+            # Make sure we don't miss any test cases
+            # or have unexpected members
+            fail(f"No test case for { fuel_type }")
 
 
 # Custom co2_g_per_litre
 def test_fuel_co2_estimate_custom_co2_g_per_litre():
     co2_g_per_litre = 1_000
-    co2_estimate_g = Fuel.BIODIESEL_20.estimate_co2_g(
-        litres=1, co2_g_per_litre=co2_g_per_litre)
 
-    assert co2_estimate_g == approx(1_000)
+    # Test using one litre,
+    # so value will match variable
+    co2_estimate_g = Fuel.BIODIESEL_20.estimate_co2_g(
+        litres=1, co2_g_per_litre=co2_g_per_litre
+    )
+
+    assert co2_estimate_g == approx(co2_g_per_litre)


### PR DESCRIPTION
**Note:** work-in-progress. Submitted for preliminary peer-review.

Closes #45 

## Changes
- Added OpenTripPlanner modes to `Mode` model. 
- Mapped most OTP modes to existing model modes. 
- Took an average of the large and small car for OTP CAR value. 
- Researched approach to get average CO2 emissions and occupancy for ferry mode.